### PR TITLE
Added Window Characteristics and Per Device Naming in Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ interface of a device, under *Settings -> Device info -> Device ID*.
     "devices": [
       { "id": "74B5A3", "exclude": true },
       { "id": "A612F0", "username": "admin", "password": "pa$$word2" },
-      { "id": "6A78BB", "colorMode": "rgb" }
+      { "id": "6A78BB", "colorMode": "rgb" },
+      { "id": "6878CE", "type": "window", "name": "Window entrance" },
+      { "id": "68C9C0", "name": "Ceiling 3"}
     ],
     "admin": {
       "enabled": true,

--- a/accessories/base.js
+++ b/accessories/base.js
@@ -29,7 +29,8 @@ module.exports = homebridge => {
 
     get name() {
       const d = this.device
-      return d.name || `${d.type} ${d.id} ${this.index}`
+      const c = this.config
+      return c.name || d.name || `${d.type} ${d.id} ${this.index}`
     }
 
     createPlatformAccessory() {

--- a/accessories/factory.js
+++ b/accessories/factory.js
@@ -96,10 +96,10 @@ module.exports = homebridge => {
           return Shelly1SwitchAccessory
         case 'SHSW-21':
         case 'SHSW-25':
+          if (accessoryType === 'window') {
+            return Shelly2WindowAccessory
+          }
           if (deviceMode === 'roller') {
-            if (deviceType === 'window') {
-              return Shelly2WindowAccessory
-            }
             return Shelly2WindowCoveringAccessory
           }
           if (accessoryType === 'outlet') {
@@ -144,7 +144,7 @@ module.exports = homebridge => {
     createAccessory(device, index, config, log,
       platformAccessory = null) {
       const accessoryConfig = this.getAccessoryConfig(config, index)
-      const accessoryType = accessoryConfig.type ||
+      const accessoryType = config.type || accessoryConfig.type ||
         this.getDefaultAccessoryType(device.type, device.mode)
       const AccessoryClass = this.getAccessoryClass(
         device.type,

--- a/accessories/factory.js
+++ b/accessories/factory.js
@@ -8,6 +8,7 @@ module.exports = homebridge => {
     Shelly2OutletAccessory,
     Shelly2SwitchAccessory,
     Shelly2WindowCoveringAccessory,
+    Shelly2WindowAccessory,
     Shelly4ProOutletAccessory,
     Shelly4ProSwitchAccessory,
     ShellyBulbColorLightbulbAccessory,
@@ -96,6 +97,9 @@ module.exports = homebridge => {
         case 'SHSW-21':
         case 'SHSW-25':
           if (deviceMode === 'roller') {
+            if (deviceType === 'window') {
+              return Shelly2WindowAccessory
+            }
             return Shelly2WindowCoveringAccessory
           }
           if (accessoryType === 'outlet') {

--- a/accessories/index.js
+++ b/accessories/index.js
@@ -35,7 +35,9 @@ module.exports = homebridge => {
   const {
     Shelly2WindowCoveringAccessory,
   } = require('./window-coverings')(homebridge)
-
+  const {
+    Shelly2WindowAccessory,
+  } = require('./window')(homebridge)
   return {
     Shelly1OutletAccessory,
     Shelly1PMOutletAccessory,
@@ -44,6 +46,7 @@ module.exports = homebridge => {
     Shelly2OutletAccessory,
     Shelly2SwitchAccessory,
     Shelly2WindowCoveringAccessory,
+    Shelly2WindowAccessory,
     Shelly4ProOutletAccessory,
     Shelly4ProSwitchAccessory,
     ShellyBulbColorLightbulbAccessory,

--- a/accessories/index.js
+++ b/accessories/index.js
@@ -37,7 +37,7 @@ module.exports = homebridge => {
   } = require('./window-coverings')(homebridge)
   const {
     Shelly2WindowAccessory,
-  } = require('./window')(homebridge)
+  } = require('./windows')(homebridge)
   return {
     Shelly1OutletAccessory,
     Shelly1PMOutletAccessory,

--- a/accessories/lightbulbs.js
+++ b/accessories/lightbulbs.js
@@ -530,6 +530,10 @@ module.exports = homebridge => {
 
     get name() {
       const d = this.device
+      const c = this.config
+      if (c.name) {
+        return c.name
+      }
       return d.name || `Shelly Bulb ${d.id}`
     }
   }

--- a/accessories/outlets.js
+++ b/accessories/outlets.js
@@ -178,7 +178,8 @@ module.exports = homebridge => {
 
     get name() {
       const d = this.device
-      return d.name || `Shelly 1 ${d.id}`
+      const c = this.config
+      return c.name || d.name || `Shelly 1 ${d.id}`
     }
   }
 
@@ -189,6 +190,10 @@ module.exports = homebridge => {
 
     get name() {
       const d = this.device
+      const c = this.config
+      if (c.name) {
+        return c.name
+      }
       return d.name || `Shelly 1PM ${d.id}`
     }
   }

--- a/accessories/sensors.js
+++ b/accessories/sensors.js
@@ -226,6 +226,10 @@ module.exports = homebridge => {
 
     get name() {
       const d = this.device
+      const c = this.config
+      if (c.name) {
+        return c.name
+      }
       return d.name || `Shelly H&T ${d.id}`
     }
 

--- a/accessories/switches.js
+++ b/accessories/switches.js
@@ -164,7 +164,9 @@ module.exports = homebridge => {
 
     get name() {
       const d = this.device
-      return d.name || `Shelly 1 ${d.id}`
+      const c = this.config
+
+      return c.name || d.name || `Shelly 1 ${d.id}`
     }
   }
 
@@ -175,7 +177,9 @@ module.exports = homebridge => {
 
     get name() {
       const d = this.device
-      return d.name || `Shelly 1PM ${d.id}`
+      const c = this.config
+
+      return c.name || d.name || `Shelly 1PM ${d.id}`
     }
   }
 
@@ -200,6 +204,10 @@ module.exports = homebridge => {
 
     get name() {
       const d = this.device
+      const c = this.config
+      if (c.name) {
+        return c.name
+      }
       if (d.name) {
         return `${d.name} #${this.index}`
       } else {

--- a/accessories/window-coverings.js
+++ b/accessories/window-coverings.js
@@ -21,8 +21,9 @@ module.exports = homebridge => {
 
     get name() {
       const d = this.device
+      const c = this.config
       const n = d.type === 'SHSW-25' ? '2.5' : '2'
-      return d.name || `Shelly ${n} ${d.id}`
+      return c.name || d.name || `Fen ${n} ${d.id}`
     }
 
     createPlatformAccessory() {

--- a/accessories/windows.js
+++ b/accessories/windows.js
@@ -21,8 +21,9 @@ module.exports = homebridge => {
 
     get name() {
       const d = this.device
+      const c = this.config
       const n = d.type === 'SHSW-25' ? '2.5' : '2'
-      return d.name || `Shelly ${n} ${d.id}`
+      return c.name || d.name || `Fen ${n} ${d.id}`
     }
 
     createPlatformAccessory() {

--- a/accessories/windows.js
+++ b/accessories/windows.js
@@ -1,0 +1,193 @@
+const { handleFailedRequest } = require('../error-handlers')
+
+module.exports = homebridge => {
+  const Accessory = homebridge.hap.Accessory
+  const Characteristic = homebridge.hap.Characteristic
+  const Service = homebridge.hap.Service
+  const ShellyAccessory = require('./base')(homebridge)
+
+  const positionStates = new Map()
+  positionStates.set('stop', Characteristic.PositionState.STOPPED)
+  positionStates.set('open', Characteristic.PositionState.INCREASING)
+  positionStates.set('close', Characteristic.PositionState.DECREASING)
+
+  class Shelly2WindowAccessory extends ShellyAccessory {
+    constructor(device, index, config, log, platformAccessory = null) {
+      super('window', device, index, config, log, platformAccessory, {
+        targetPosition: device.rollerPosition,
+        _updatingTargetPosition: false,
+      })
+    }
+
+    get name() {
+      const d = this.device
+      const n = d.type === 'SHSW-25' ? '2.5' : '2'
+      return d.name || `Shelly ${n} ${d.id}`
+    }
+
+    createPlatformAccessory() {
+      const pa = super.createPlatformAccessory()
+
+      pa.category = Accessory.Categories.WINDOW
+      pa.context.mode = 'roller'
+
+      const coveringService = new Service.Window()
+        .setCharacteristic(
+          Characteristic.PositionState,
+          positionStates.get(this.device.rollerState)
+        )
+        .setCharacteristic(
+          Characteristic.CurrentPosition,
+          this.device.rollerPosition
+        )
+        .setCharacteristic(
+          Characteristic.TargetPosition,
+          this.targetPosition
+        )
+
+      pa.addService(coveringService)
+
+      return pa
+    }
+
+    setupEventHandlers() {
+      super.setupEventHandlers()
+
+      const d = this.device
+
+      this.platformAccessory
+        .getService(Service.Window)
+        .getCharacteristic(Characteristic.TargetPosition)
+        .on('set', async (newValue, callback) => {
+          if (newValue === this.targetPosition) {
+            callback()
+            return
+          }
+
+          this.log.debug(
+            'Setting target roller shutter position of device',
+            d.type,
+            d.id,
+            'to',
+            newValue
+          )
+
+          try {
+            await d.setRollerPosition(newValue)
+            this.targetPosition = newValue
+            callback()
+          } catch (e) {
+            handleFailedRequest(
+              this.log,
+              d,
+              e,
+              'Failed to set roller shutter position'
+            )
+            callback(e)
+          }
+        })
+
+      d
+        .on('change:rollerState', this.rollerStateChangeHandler, this)
+        .on('change:rollerPosition', this.rollerPositionChangeHandler, this)
+    }
+
+    rollerStateChangeHandler(newValue) {
+      this.log.debug(
+        'Roller shutter state of device',
+        this.device.type,
+        this.device.id,
+        'changed to',
+        newValue
+      )
+
+      this.platformAccessory
+        .getService(Service.Window)
+        .getCharacteristic(Characteristic.PositionState)
+        .setValue(positionStates.get(newValue))
+
+      this._updateTargetPosition()
+    }
+
+    rollerPositionChangeHandler(newValue) {
+      this.log.debug(
+        'Roller position of device',
+        this.device.type,
+        this.device.id,
+        'changed to',
+        newValue
+      )
+
+      this.platformAccessory
+        .getService(Service.Window)
+        .getCharacteristic(Characteristic.CurrentPosition)
+        .setValue(newValue)
+
+      this._updateTargetPosition()
+    }
+
+    _updateTargetPosition() {
+      if (this._updatingTargetPosition) {
+        return
+      }
+      this._updatingTargetPosition = true
+
+      setImmediate(() => {
+        const state = this.device.rollerState
+        const position = this.device.rollerPosition
+        let targetPosition = null
+
+        if (state === 'stop') {
+          targetPosition = position
+        } else if (state === 'open' && this.targetPosition <= position) {
+          // we don't know what the target position is here, but we set it
+          // to 100 so that the interface shows that the roller is opening
+          targetPosition = 100
+        } else if (state === 'close' && this.targetPosition >= position) {
+          // we don't know what the target position is here, but we set it
+          // to 0 so that the interface shows that the roller is closing
+          targetPosition = 0
+        }
+
+        if (targetPosition !== null && targetPosition !== this.targetPosition) {
+          this.log.debug(
+            'Setting target roller shutter position of device',
+            this.device.type,
+            this.device.id,
+            'to',
+            targetPosition
+          )
+
+          this.targetPosition = targetPosition
+
+          this.platformAccessory
+            .getService(Service.Window)
+            .getCharacteristic(Characteristic.TargetPosition)
+            .setValue(targetPosition)
+        }
+
+        this._updatingTargetPosition = false
+      })
+    }
+
+    detach() {
+      super.detach()
+
+      this.device
+        .removeListener(
+          'change:rollerState',
+          this.rollerStateChangeHandler,
+          this
+        )
+        .removeListener(
+          'change:rollerPosition',
+          this.rollerPositionChangeHandler,
+          this
+        )
+    }
+  }
+
+  return {
+    Shelly2WindowAccessory,
+  }
+}

--- a/platform.js
+++ b/platform.js
@@ -129,6 +129,7 @@ module.exports = homebridge => {
 
     addDevice(device) {
       const deviceConfig = this.getDeviceConfig(device.id)
+      this.log('creating device', deviceConfig)
       const accessories = AccessoryFactory.createAccessories(
         device,
         deviceConfig,
@@ -199,6 +200,7 @@ module.exports = homebridge => {
         deviceConfig,
         ctx.index || 0
       )
+      this.log.info(accessoryConfig)
       const defaultAccessoryType = AccessoryFactory.getDefaultAccessoryType(
         ctx.type,
         ctx.mode

--- a/test/mocks/homebridge.js
+++ b/test/mocks/homebridge.js
@@ -6,6 +6,7 @@ Accessory.Categories = {
   SENSOR: 'SENSOR',
   SWITCH: 'SWITCH',
   WINDOW_COVERING: 'WINDOW_COVERING',
+  WINDOW: 'WINDOW',
 }
 
 class Characteristic extends EventEmitter {
@@ -343,8 +344,19 @@ class WindowCovering extends Service {
     this.addCharacteristic(TargetPosition)
   }
 }
-Service.WindowCovering = WindowCovering
 
+class Window extends Service {
+  constructor() {
+    super()
+
+    this.addCharacteristic(CurrentPosition)
+    this.addCharacteristic(PositionState)
+    this.addCharacteristic(TargetPosition)
+  }
+}
+
+Service.WindowCovering = WindowCovering
+Service.Window = Window
 class Homebridge extends EventEmitter {
   constructor() {
     super()


### PR DESCRIPTION
Hey. I went for it and implemented some features.
with this you can set a name per device in config. (name: xyz) so if something happens you don't have to identify all of the switches.
also you can now add type: window to a shelly 2.5. maybe this is also good for #20 ?
i did not expand the tests.