### PR TITLE
Change default webserver port.

### DIFF
--- a/admin/index.js
+++ b/admin/index.js
@@ -16,7 +16,7 @@ class AdminServer {
 
   listen() {
     return new Promise((resolve, reject) => {
-      const server = this.app.listen(this.config.port || 8080, () => {
+      const server = this.app.listen(this.config.port || 8181, () => {
         resolve(server.address().port)
       }).on('error', e => {
         reject(e)


### PR DESCRIPTION
homebridge-config uses port 8080 as a standard hence when adding this project, you have to manually specify a port whereas it should use 8181 as a default.