### PR TITLE
Expose the name given in device settings

### DIFF
--- a/accessories/base.js
+++ b/accessories/base.js
@@ -139,6 +139,12 @@ module.exports = homebridge => {
           d.settings.hwinfo.hw_revision
         )
       }
+      
+      if (d.settings && d.settings.name) {
+        infoService.setCharacteristic(
+          Characteristic.Name, d.settings.name
+        )
+      }
     }
 
     /**


### PR DESCRIPTION
Update Characteristic.Name (exposed in homekit) by the name given in device settings. No need for extra configuration.