### PR TITLE
Added support for shelly motion

### DIFF
--- a/accessories/factory.js
+++ b/accessories/factory.js
@@ -29,6 +29,7 @@ module.exports = homebridge => {
     ShellyRelayMotionSensorAccessory,
     ShellyRelayOccupancySensorAccessory,
     ShellySenseAccessory,
+    ShellyMotionAccessory,
   } = require('./sensors')(homebridge)
 
   const {
@@ -559,7 +560,21 @@ module.exports = homebridge => {
       return new ShellyFloodAccessory(this.device, ...opts)
     }
   }
-  FACTORIES.set('SHWT-1', ShellyFloodFactory)
+  FACTORIES.set('SHWT-1', ShellyFloodFactory) 
+
+  /**
+   * Shelly Motion factory.
+   */
+  class ShellyMotionFactory extends AccessoryFactory {
+      get defaultAccessoryType() {
+          return 'sensor'
+      }
+
+      _createAccessory(accessoryType, ...opts) {
+          return new ShellyMotionAccessory(this.device, ...opts)
+      }
+  }
+  FACTORIES.set('SHMOS-01', ShellyMotionFactory)
 
   /**
    * Returns the factory for the given device.

--- a/accessories/sensors.js
+++ b/accessories/sensors.js
@@ -142,6 +142,16 @@ module.exports = homebridge => {
     }
   }
 
+  class ShellyMotionAccessory extends ShellySensorAccessory {
+  constructor(device, index, config, log) {
+    super(device, index, config, log, [
+        new MotionSensorAbility('motion'),
+        new LightSensorAbility('illuminance'),
+        new BatteryAbility('battery'),
+    ]);
+   }
+  }
+
   return {
     ShellyDoorWindowAccessory,
     ShellyDoorWindow2Accessory,
@@ -152,5 +162,6 @@ module.exports = homebridge => {
     ShellyRelayMotionSensorAccessory,
     ShellyRelayOccupancySensorAccessory,
     ShellySenseAccessory,
+    ShellyMotionAccessory,
   }
 }


### PR DESCRIPTION
After [this ](https://github.com/alexryd/node-shellies/pull/19) pull request has been pulled these changes here should get the new shelly motion sensor running in homebridge.

The new shelly motion also provides a vibration sensor which I completely ignored in this implementation because I couldn't find an appropriate HAP characteristic. I'm not sure if this can be implemented as second motion sensor in future...  

