### PR TITLE
Added channel configuration and names

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ interface of a device, under *Settings -> Device info -> Device ID*.
 * `"colorMode"` - set to `"rgbw"` (default) to have HomeKit control all four
   channels of the device (R, G, B, and W), or to `"rgb"` to omit the W channel.
 
+#### Channel configuration
+*Applies to 2.5 in switch mode, 4Pro, HD, Uni and RGBW2 in white mode.*
+* `"channels"` - configure channel name or exclude a channel (see example)
+
 ### Example configuration
 ```json
 "platforms": [
@@ -146,6 +150,14 @@ interface of a device, under *Settings -> Device info -> Device ID*.
       { "id": "6A78BB", "colorMode": "rgb" },
       { "id": "AD2214", "name": "My Device" },
       { "id": "1D56AF", "type": "outlet" }
+      { 
+        "id": "A69E7F",
+        "channels":
+        {
+          "0": { "name": "Channel 0" }
+          "2": { "exclude": true }
+        }
+      }
     ],
     "admin": {
       "enabled": true,

--- a/accessories/base.js
+++ b/accessories/base.js
@@ -136,11 +136,9 @@ module.exports = homebridge => {
         )
       }
 
-      if (d.settings && d.settings.name && d.settings.name === this.name) {
-        infoService.setCharacteristic(
-          Characteristic.Name, this.name
-        )
-      }
+      infoService.setCharacteristic(
+        Characteristic.Name, this.name
+      )
     }
 
     /**

--- a/accessories/factory.js
+++ b/accessories/factory.js
@@ -657,10 +657,9 @@ module.exports = homebridge => {
 
       // helper function that creates the given number of accessories
       const multiple = num => {
-        return Array.from(
-          { length: num },
-          (_, i) => this.createAccessory(device, i, config, log)
-        )
+        return Array.from({ length: num }, (_, i) => i)
+            .filter((i) => !config.channels || !config.channels[i] || !config.channels[i].exclude)
+            .map((i) => this.createAccessory(device, i, config, log))
       }
 
       return multiple(factory.numberOfAccessories)

--- a/accessories/lightbulbs.js
+++ b/accessories/lightbulbs.js
@@ -145,6 +145,26 @@ module.exports = homebridge => {
       ))
     }
 
+    /**
+     * The name of this accessory, as specified by either the configuration, the
+     * device or the `defaultName` property.
+     */
+    get name() {
+      if (this.config.channels && this.config.channels[this.index] && this.config.channels[this.index].name) {
+        return this.config.channels[this.index].name
+      } else if (this.config.name) {
+        return this.config.name
+      }
+
+      const d = this.device
+      if (d.settings && d.settings.lights && d.settings.lights[this.index] && d.settings.lights[this.index].name) {
+        return d.settings.lights[this.index].name
+      } else if (this.device.name) {
+        return this.device.name
+      }
+      return this.defaultName
+    }
+
     get category() {
       return Accessory.Categories.LIGHTBULB
     }

--- a/accessories/switches.js
+++ b/accessories/switches.js
@@ -18,6 +18,26 @@ module.exports = homebridge => {
       }
     }
 
+    /**
+     * The name of this accessory, as specified by either the configuration, the
+     * device or the `defaultName` property.
+     */
+    get name() {
+      if (this.config.channels && this.config.channels[this.index] && this.config.channels[this.index].name) {
+        return this.config.channels[this.index].name
+      } else if (this.config.name) {
+        return this.config.name
+      }
+
+      const d = this.device
+      if (d.settings && d.settings.relays && d.settings.relays[this.index] && d.settings.relays[this.index].name) {
+        return d.settings.relays[this.index].name
+      } else if (this.device.name) {
+        return this.device.name
+      }
+      return this.defaultName
+    }
+
     get category() {
       return Accessory.Categories.SWITCH
     }

--- a/config.schema.json
+++ b/config.schema.json
@@ -115,6 +115,23 @@
             "exclude": {
               "title": "Exclude device",
               "type": "boolean"
+            },
+            "channels": {
+              "title": "Channel configuration",
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "title": "Channel name",
+                    "typeof": "string"
+                  },
+                  "exclude": {
+                    "title": "Exclude channel",
+                    "type": "boolean"
+                  }
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
This Pull Request adds per-channel configuration, currently supporting a channel name and to exclude specific channels. In my case, I can name or exclude each channel of a RGBW2 in white-mode as well as channels of Shelly 2.5

The changes now also fetch the channel's name from a device if available and uses it instead of the device name.

This should fix the following issues: https://github.com/alexryd/homebridge-shelly/issues/277 https://github.com/alexryd/homebridge-shelly/issues/261 https://github.com/alexryd/homebridge-shelly/issues/236 https://github.com/alexryd/homebridge-shelly/issues/219 https://github.com/alexryd/homebridge-shelly/issues/116 https://github.com/alexryd/homebridge-shelly/issues/198