### PR TITLE
Feat detached and skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,15 @@ interface of a device, under *Settings -> Device info -> Device ID*.
 #### Shelly 2.5 configurations
 * `"type"` - in roller mode, the device can be identified as either `"door"`,
   `"garageDoorOpener"`, `"window"` or `"windowCovering"` (default).
+* For detached mode, you can use a `type` of `"detachedContactSensor"`; in
+  this configuration, you won't be able to control the relay through HomeKit
+  (you can still control it through the Shelly directly).  What will be
+  exposed instead is the status of the connected light switch.
+* You can also specify certain types on a per-channel basis: `skip` will
+  cause Homebridge to not configure that channel at all, and other options
+  (like `detachedContactSensor`, `switch`, `outlet`, etc.) make it possible
+  to have a heterogenous mixture of types and configurations attached to a
+  single device.
 
 #### Shelly RGBW2 configurations
 * `"colorMode"` - set to `"rgbw"` (default) to have HomeKit control all four
@@ -146,6 +155,7 @@ interface of a device, under *Settings -> Device info -> Device ID*.
       { "id": "6A78BB", "colorMode": "rgb" },
       { "id": "AD2214", "name": "My Device" },
       { "id": "1D56AF", "type": "outlet" }
+      { "id": "921A84CFBBA7", "type": "outlet", "channels": [{"type": "skip"}, {}] }
     ],
     "admin": {
       "enabled": true,
@@ -160,7 +170,8 @@ If you have a Shelly device that is not yet supported by this plugin you can
 help adding support for it by following these steps:
 
 1. Run `$ homebridge-shelly describe <ip-address>` with the IP address of the
-   Shelly device.
+   Shelly device.  (If you are using HTTP auth, you'll need to edit the script
+   to hardcode those values.)
 2. Create [a new issue](https://github.com/alexryd/homebridge-shelly/issues)
    and post the output from the previous command.
 

--- a/abilities/contact-sensor.js
+++ b/abilities/contact-sensor.js
@@ -9,17 +9,22 @@ module.exports = homebridge => {
      * @param {string} detectedProperty - The device property used to indicate
      * whether contact has been detected.
      */
-    constructor(detectedProperty) {
+    constructor(detectedProperty, invert=true) {
       super(
         Service.ContactSensor,
         Characteristic.ContactSensorState,
         detectedProperty
       )
+
+      this.invert = invert
     }
 
     _valueToHomeKit(value) {
       const CSS = Characteristic.ContactSensorState
-      return !value ? CSS.CONTACT_DETECTED : CSS.CONTACT_NOT_DETECTED
+      if ( this.invert ) {
+        return !value ? CSS.CONTACT_DETECTED : CSS.CONTACT_NOT_DETECTED
+      }
+      return value ? CSS.CONTACT_DETECTED : CSS.CONTACT_NOT_DETECTED
     }
   }
 

--- a/accessories/sensors.js
+++ b/accessories/sensors.js
@@ -82,6 +82,22 @@ module.exports = homebridge => {
     }
   }
 
+  class ShellyInputContactSensorAccessory extends ShellyAccessory {
+    constructor(device, index, config, log, powerMeterIndex = false) {
+      super('contactSensor', device, index, config, log)
+
+      this.abilities.push(new ContactSensorAbility('input' + index, false))
+
+      if (powerMeterIndex !== false) {
+        this.abilities.push(new PowerMeterAbility('power' + powerMeterIndex))
+      }
+    }
+
+    get category() {
+      return Accessory.Categories.SENSOR
+    }
+  }
+
   class ShellyRelayContactSensorAccessory extends ShellyAccessory {
     constructor(device, index, config, log, powerMeterIndex = false) {
       super('contactSensor', device, index, config, log)
@@ -158,6 +174,7 @@ module.exports = homebridge => {
     ShellyFloodAccessory,
     ShellyGasSmokeSensorAccessory,
     ShellyHTAccessory,
+    ShellyInputContactSensorAccessory,
     ShellyRelayContactSensorAccessory,
     ShellyRelayMotionSensorAccessory,
     ShellyRelayOccupancySensorAccessory,

--- a/bin/homebridge-shelly
+++ b/bin/homebridge-shelly
@@ -28,6 +28,7 @@ const describe = async host => {
   console.log(v('Type', device.type))
   console.log(v('CoAP description', JSON.stringify(description.payload)))
   console.log(v('CoAP status', JSON.stringify(status.payload)))
+  //device.setAuthCredentials('username', 'password') // hardcode Basic auth here, if used
   console.log(v('HTTP Settings:', JSON.stringify(await device.getSettings())))
   console.log(v('HTTP Status:', JSON.stringify(await device.getStatus())))
 }

--- a/platform.js
+++ b/platform.js
@@ -141,10 +141,10 @@ module.exports = homebridge => {
 
         try {
           if (!this.addDevice(device)) {
-            this.log.info('Unknown device, so skipping it')
+            this.log.info(`Unknown device ${device}, so skipping it`)
           }
         } catch (e) {
-          this.log.error('Failed to add device')
+          this.log.error(`Failed to add device ${device} [${device.type}], ${device.id}@${device.host} due to ${e}`)
           if (e.stack) {
             this.log.error(e.stack)
           }
@@ -205,6 +205,7 @@ module.exports = homebridge => {
     removeDevice(device) {
       const deviceWrapper = this.deviceWrappers.get(device)
       if (!deviceWrapper) {
+        this.log.info(`No deviceWrapper found for ${device.id} in removeDevice().`)
         return
       }
 


### PR DESCRIPTION
This PR enables device configurations like this (for two 2.5s):

```json
[
    {
        "id": "0123456789ABCD",
        "channels": [
            {},
            {
                "type": "detachedContactSensor"
            }
        ]
    },
    {
        "id": "FEDCBA986754",
        "type": "detachedContactSensor",
        "channels": [
            {
                "type": "skip"
            }
        ]
    }
]
```

It also enhances logging in a few useful spots, and adds a hint for how to get `describe` to work for those who have enabled HTTP auth.

Tested only insofar as my little setup enables me to test.  I apologize in advance for the crimes I have doubtless committed against idiomatic Node; I plead ignorance and a genuine belief that working, ugly code is better than no code at all.

Closes #87 
Relevant to (but doesn't yet close) #219 

