### PR TITLE
feat: include device ID in admin for named Shellies

### DIFF
--- a/admin/static/scripts.js
+++ b/admin/static/scripts.js
@@ -31,7 +31,7 @@ function renderDevice(list, device) {
       $('<div class="heading">')
         .append(
           $('<div class="title">')
-            .text(device.name || (device.modelName + ' ' + device.id))
+            .text(device.name ? device.name + ' [' + device.id + ']' : (device.modelName + ' ' + device.id))
         )
         .append(
           $('<a class="host-link" target="_blank">')


### PR DESCRIPTION
The device ID is needed in order to configure the devices array, but disappears from view when one assigns names to one's devices.  This change restores the device ID, thereby easing per-device configuration.