### PR TITLE
Prevent PositionableAbility.targetPosition from being set to 0% or 100% unless the Shelly has been manually controlled

### DIFF
--- a/abilities/base.js
+++ b/abilities/base.js
@@ -83,6 +83,7 @@ module.exports = homebridge => {
       this._setPositionTimeout = null
       this._targetPosition = null
       this._targetPositionTimeout = null
+      this._prevStopPosition = 0
     }
 
     /**
@@ -229,10 +230,6 @@ module.exports = homebridge => {
         newValue
       )
 
-      this.service
-        .getCharacteristic(Characteristic.CurrentPosition)
-        .setValue(this.position)
-
       this._updateTargetPositionDebounced()
     }
 
@@ -261,11 +258,17 @@ module.exports = homebridge => {
 
       if (state === 'stop') {
         targetPosition = position
-      } else if (state === 'open' && this.targetPosition <= position) {
+        this._prevStopPosition = position
+
+        this.service
+          .getCharacteristic(Characteristic.CurrentPosition)
+          .setValue(position)
+
+      } else if (state === 'open' && this.targetPosition === this._prevStopPosition) {
         // we don't know what the target position is here, but we set it
         // to 100 so that the interface shows that the roller is opening
         targetPosition = 100
-      } else if (state === 'close' && this.targetPosition >= position) {
+      } else if (state === 'close' && this.targetPosition === this._prevStopPosition) {
         // we don't know what the target position is here, but we set it
         // to 0 so that the interface shows that the roller is closing
         targetPosition = 0


### PR DESCRIPTION
After specifying a target position using the Home app, the slider would automatically jump to 0 or 100 (depending on wether it was moving up or down) until the Shelly stopped moving. This pull request changes this behavior. Now the target position only gets set to 0 / 100 if the user manually controls the Shelly using either the Shelly app or a physical button.