### PR TITLE
Expose current and voltage power meter properties

### DIFF
--- a/accessories/factory.js
+++ b/accessories/factory.js
@@ -135,6 +135,14 @@ module.exports = homebridge => {
       return this.numberOfAccessories
     }
 
+    get enableElectricCurrent() {
+      return false
+    }
+
+    get enableVoltage() {
+      return false
+    }
+
     _createAccessory(accessoryType, index, config, log) {
       const powerMeterIndex = this.numberOfPowerMeters > 0
         ? Math.min(index, this.numberOfPowerMeters - 1)
@@ -165,7 +173,12 @@ module.exports = homebridge => {
       } else if (accessoryType === 'valve') {
         return new ShellyRelayValveAccessory(this.device, ...opts)
       }
-      return new ShellyRelaySwitchAccessory(this.device, ...opts)
+      return new ShellyRelaySwitchAccessory(
+        this.device,
+        ...opts,
+        this.enableElectricCurrent,
+        this.enableVoltage
+      )
     }
   }
 

--- a/accessories/factory.js
+++ b/accessories/factory.js
@@ -308,6 +308,10 @@ module.exports = homebridge => {
     get numberOfPowerMeters() {
       return 2
     }
+
+    get enableVoltage() {
+      return true
+    }
   }
   FACTORIES.set('SHEM', ShellyEMFactory)
 

--- a/accessories/outlets.js
+++ b/accessories/outlets.js
@@ -5,7 +5,8 @@ module.exports = homebridge => {
   const { ShellyRelayAccessory } = require('./base')(homebridge)
 
   class ShellyRelayOutletAccessory extends ShellyRelayAccessory {
-    constructor(device, index, config, log, powerMeterIndex = false) {
+    constructor(device, index, config, log, powerMeterIndex = false,
+      enableElectricCurrent = false, enableVoltage = false) {
       super('outlet', device, index, config, log)
 
       const consumptionProperty = powerMeterIndex !== false
@@ -19,7 +20,11 @@ module.exports = homebridge => {
       ))
 
       if (consumptionProperty) {
-        this.addPowerMeter(consumptionProperty)
+        this.addPowerMeter(
+          consumptionProperty,
+          enableElectricCurrent ? 'current' + powerMeterIndex : null,
+          enableVoltage ? 'voltage' + powerMeterIndex : null,
+        )
       }
     }
 

--- a/accessories/switches.js
+++ b/accessories/switches.js
@@ -5,7 +5,8 @@ module.exports = homebridge => {
   const { ShellyRelayAccessory } = require('./base')(homebridge)
 
   class ShellyRelaySwitchAccessory extends ShellyRelayAccessory {
-    constructor(device, index, config, log, powerMeterIndex = false) {
+    constructor(device, index, config, log, powerMeterIndex = false,
+      enableElectricCurrent = false, enableVoltage = false) {
       super('switch', device, index, config, log)
 
       this.abilities.push(new SwitchAbility(
@@ -14,7 +15,11 @@ module.exports = homebridge => {
       ))
 
       if (powerMeterIndex !== false) {
-        this.addPowerMeter('power' + powerMeterIndex)
+        this.addPowerMeter(
+          'power' + powerMeterIndex,
+          enableElectricCurrent ? 'current' + powerMeterIndex : null,
+          enableVoltage ? 'voltage' + powerMeterIndex : null,
+        )
       }
     }
 

--- a/accessories/valves.js
+++ b/accessories/valves.js
@@ -5,7 +5,8 @@ module.exports = homebridge => {
   const ValveAbility = require('../abilities/valve')(homebridge)
 
   class ShellyRelayValveAccessory extends ShellyRelayAccessory {
-    constructor(device, index, config, log, powerMeterIndex = false) {
+    constructor(device, index, config, log, powerMeterIndex = false,
+      enableElectricCurrent = false, enableVoltage = false) {
       super('valve', device, index, config, log)
 
       const consumptionProperty = powerMeterIndex !== false
@@ -19,7 +20,11 @@ module.exports = homebridge => {
       ))
 
       if (consumptionProperty) {
-        this.addPowerMeter(consumptionProperty)
+        this.addPowerMeter(
+          consumptionProperty,
+          enableElectricCurrent ? 'current' + powerMeterIndex : null,
+          enableVoltage ? 'voltage' + powerMeterIndex : null,
+        )
       }
     }
 

--- a/util/custom-characteristics.js
+++ b/util/custom-characteristics.js
@@ -27,6 +27,7 @@ module.exports = homebridge => {
       this.setProps({
         format: Formats.FLOAT,
         unit: 'A',
+        minStep: 0.1,
         perms: [Perms.READ, Perms.NOTIFY],
       })
       this.value = this.getDefaultValue()
@@ -40,6 +41,7 @@ module.exports = homebridge => {
       this.setProps({
         format: Formats.FLOAT,
         unit: 'V',
+        minStep: 0.1,
         perms: [Perms.READ, Perms.NOTIFY],
       })
       this.value = this.getDefaultValue()


### PR DESCRIPTION
Add capability to expose current and voltage readings for accessories that have a power meter (switches, outlets, valves) (e.g. Shelly EM, like in this PR).