### PR TITLE
Add total consumption for Shelly EM

### DIFF
--- a/accessories/base.js
+++ b/accessories/base.js
@@ -210,15 +210,18 @@ module.exports = homebridge => {
      * This method must be called before setup().
      * @param {string} consumptionProperty - The device property used to
      * indicate the current power consumption (Watt).
+     * @param {string} totalConsumptionProperty - The device property used to
+     * indicate the total current power consumption (Kilowatt-hour).
      * @param {string} electricCurrentProperty - The device property used to
      * indicate the amount of electric current (Ampere).
      * @param {string} voltageProperty - The device property used to indicate
      * the current voltage (Volt).
      */
-    addPowerMeter(consumptionProperty, electricCurrentProperty = null,
-      voltageProperty = null) {
+    addPowerMeter(consumptionProperty, totalConsumptionProperty = null,
+      electricCurrentProperty = null, voltageProperty = null) {
       this.abilities.push(new PowerMeterAbility(
         consumptionProperty,
+        totalConsumptionProperty,
         electricCurrentProperty,
         voltageProperty
       ))

--- a/accessories/factory.js
+++ b/accessories/factory.js
@@ -135,6 +135,10 @@ module.exports = homebridge => {
       return this.numberOfAccessories
     }
 
+    get enableTotalConsumption() {
+      return false
+    }
+
     _createAccessory(accessoryType, index, config, log) {
       const powerMeterIndex = this.numberOfPowerMeters > 0
         ? Math.min(index, this.numberOfPowerMeters - 1)
@@ -165,7 +169,11 @@ module.exports = homebridge => {
       } else if (accessoryType === 'valve') {
         return new ShellyRelayValveAccessory(this.device, ...opts)
       }
-      return new ShellyRelaySwitchAccessory(this.device, ...opts)
+      return new ShellyRelaySwitchAccessory(
+        this.device,
+        ...opts,
+        this.enableTotalConsumption
+      )
     }
   }
 

--- a/accessories/factory.js
+++ b/accessories/factory.js
@@ -303,6 +303,10 @@ module.exports = homebridge => {
     get numberOfPowerMeters() {
       return 2
     }
+
+    get enableTotalConsumption() {
+      return true
+    }
   }
   FACTORIES.set('SHEM', ShellyEMFactory)
 

--- a/accessories/outlets.js
+++ b/accessories/outlets.js
@@ -5,7 +5,8 @@ module.exports = homebridge => {
   const { ShellyRelayAccessory } = require('./base')(homebridge)
 
   class ShellyRelayOutletAccessory extends ShellyRelayAccessory {
-    constructor(device, index, config, log, powerMeterIndex = false) {
+    constructor(device, index, config, log, powerMeterIndex = false,
+      enableTotalConsumption = false) {
       super('outlet', device, index, config, log)
 
       const consumptionProperty = powerMeterIndex !== false
@@ -19,7 +20,10 @@ module.exports = homebridge => {
       ))
 
       if (consumptionProperty) {
-        this.addPowerMeter(consumptionProperty)
+        this.addPowerMeter(
+          consumptionProperty,
+          enableTotalConsumption ? 'energyCounter' + powerMeterIndex : null
+        )
       }
     }
 

--- a/accessories/switches.js
+++ b/accessories/switches.js
@@ -5,7 +5,8 @@ module.exports = homebridge => {
   const { ShellyRelayAccessory } = require('./base')(homebridge)
 
   class ShellyRelaySwitchAccessory extends ShellyRelayAccessory {
-    constructor(device, index, config, log, powerMeterIndex = false) {
+    constructor(device, index, config, log, powerMeterIndex = false,
+      enableTotalConsumption = false) {
       super('switch', device, index, config, log)
 
       this.abilities.push(new SwitchAbility(
@@ -14,7 +15,10 @@ module.exports = homebridge => {
       ))
 
       if (powerMeterIndex !== false) {
-        this.addPowerMeter('power' + powerMeterIndex)
+        this.addPowerMeter(
+          'power' + powerMeterIndex,
+          enableTotalConsumption ? 'energyCounter' + powerMeterIndex : null
+        )
       }
     }
 

--- a/accessories/valves.js
+++ b/accessories/valves.js
@@ -5,7 +5,8 @@ module.exports = homebridge => {
   const ValveAbility = require('../abilities/valve')(homebridge)
 
   class ShellyRelayValveAccessory extends ShellyRelayAccessory {
-    constructor(device, index, config, log, powerMeterIndex = false) {
+    constructor(device, index, config, log, powerMeterIndex = false,
+      enableTotalConsumption = false) {
       super('valve', device, index, config, log)
 
       const consumptionProperty = powerMeterIndex !== false
@@ -19,7 +20,10 @@ module.exports = homebridge => {
       ))
 
       if (consumptionProperty) {
-        this.addPowerMeter(consumptionProperty)
+        this.addPowerMeter(
+          consumptionProperty,
+          enableTotalConsumption ? 'energyCounter' + powerMeterIndex : null
+        )
       }
     }
 

--- a/util/custom-characteristics.js
+++ b/util/custom-characteristics.js
@@ -21,6 +21,21 @@ module.exports = homebridge => {
   }
   ConsumptionCharacteristic.UUID = 'E863F10D-079E-48FF-8F27-9C2605A29F52'
 
+  class TotalConsumptionCharacteristic extends Characteristic {
+    constructor() {
+      super('Total Consumption', TotalConsumptionCharacteristic.UUID)
+      this.setProps({
+        format: Formats.FLOAT,
+        unit: 'kWh',
+        minValue: 0,
+        minStep: 0.001,
+        perms: [Perms.READ, Perms.NOTIFY],
+      })
+      this.value = this.getDefaultValue()
+    }
+  }
+  TotalConsumptionCharacteristic.UUID = 'E863F10C-079E-48FF-8F27-9C2605A29F52'
+
   class ElectricCurrentCharacteristic extends Characteristic {
     constructor() {
       super('Electric Current', ElectricCurrentCharacteristic.UUID)
@@ -49,6 +64,7 @@ module.exports = homebridge => {
 
   return {
     ConsumptionCharacteristic,
+    TotalConsumptionCharacteristic,
     ElectricCurrentCharacteristic,
     VoltageCharacteristic,
   }

--- a/util/custom-services.js
+++ b/util/custom-services.js
@@ -2,6 +2,7 @@
 module.exports = homebridge => {
   const {
     ConsumptionCharacteristic,
+    TotalConsumptionCharacteristic,
     ElectricCurrentCharacteristic,
     VoltageCharacteristic,
   } = require('./custom-characteristics')(homebridge)
@@ -13,6 +14,7 @@ module.exports = homebridge => {
       super(displayName, PowerMeterService.UUID, subtype)
 
       this.addCharacteristic(ConsumptionCharacteristic)
+      this.addOptionalCharacteristic(TotalConsumptionCharacteristic)
       this.addOptionalCharacteristic(ElectricCurrentCharacteristic)
       this.addOptionalCharacteristic(VoltageCharacteristic)
     }


### PR DESCRIPTION
Add capability to expose total consumption readings for accessories that have a power meter (switches, outlets, valves) (e.g. Shelly EM, like in this PR).

Note: it will conflict with https://github.com/alexryd/homebridge-shelly/pull/377, but I'll sort it out once the first is merged.