### PR TITLE
Expose second button of Shelly 1L to Homebridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ interface of a device, under *Settings -> Device info -> Device ID*.
   types are `"contactSensor"`, `"motionSensor"`, `"occupancySensor"`,
   `"outlet"`, `"switch"` (default) and `"valve"`.
 
+#### Shelly 1L configurations
+* `"type"` - sets the type of the secondary button (only useful when configured
+  to detached mode). Available types are:
+  
+  * `"switch"` (default) disables the secondary button.
+  * `"statelessSwitch"` triggers short, double or long press (useful for push
+    buttons).
+  * `"statelessToggle"` always triggers a single press with each state change
+    (useful for toggle switches).
+
 #### Shelly 2.5 configurations
 * `"type"` - in roller mode, the device can be identified as either `"door"`,
   `"garageDoorOpener"`, `"window"` or `"windowCovering"` (default).

--- a/accessories/factory.js
+++ b/accessories/factory.js
@@ -35,6 +35,7 @@ module.exports = homebridge => {
   const {
     ShellyButton1StatelessSwitchAccessory,
     ShellyInputStatelessSwitchAccessory,
+    ShellyInputStatelessToggleAccessory,
   } = require('./stateless-switches')(homebridge)
 
   const {
@@ -515,7 +516,25 @@ module.exports = homebridge => {
   /**
    * Shelly 1L factory.
    */
-  class Shelly1LFactory extends RelayAccessoryFactory {}
+  class Shelly1LFactory extends RelayAccessoryFactory {
+    get numberOfAccessories() {
+      return 2
+    }
+
+    _createAccessory(accessoryType, index, config, log) {
+      if (index == 0) {
+        return this._createAccessoryForRelay(accessoryType, index, config, log)
+      }
+      else {
+        if (accessoryType === "statelessToggle") {
+          return new ShellyInputStatelessToggleAccessory(this.device, index, config, log, 1, 1)
+        }
+        else if (accessoryType === "statelessSwitch") {
+          return new ShellyInputStatelessSwitchAccessory(this.device, index, config, log, 1, 1)
+        }
+      }
+    }
+  }
   FACTORIES.set('SHSW-L', Shelly1LFactory)
 
   /**

--- a/accessories/stateless-switches.js
+++ b/accessories/stateless-switches.js
@@ -2,8 +2,10 @@
 module.exports = homebridge => {
   const BatteryAbility = require('../abilities/battery')(homebridge)
   const ServiceLabelAbility = require('../abilities/service-label')(homebridge)
-  const StatelessProgrammableSwitchAbility =
-    require('../abilities/stateless-programmable-switch')(homebridge)
+  const {
+    StatelessProgrammableSwitchAbility,
+    StatelessProgrammableToggleAbility,
+  } = require('../abilities/stateless-programmable-switch')(homebridge)
   const { ShellyAccessory } = require('./base')(homebridge)
 
   class ShellyButton1StatelessSwitchAccessory extends ShellyAccessory {
@@ -19,19 +21,42 @@ module.exports = homebridge => {
   }
 
   class ShellyInputStatelessSwitchAccessory extends ShellyAccessory {
-    constructor(device, index, config, log, numberOfInputs = 1) {
+    constructor(device, index, config, log, numberOfInputs = 1, numberOfFirstInput = 0) {
       super('statelessSwitch', device, index, config, log)
 
       if (numberOfInputs === 1) {
         this.abilities.push(new StatelessProgrammableSwitchAbility(
-          'inputEvent0',
-          'inputEventCounter0'
+          'inputEvent' + numberOfFirstInput,
+          'inputEventCounter' + numberOfFirstInput
         ))
       } else {
         for (let i = 0; i < numberOfInputs; i++) {
           this.abilities.push(new StatelessProgrammableSwitchAbility(
-            'inputEvent' + i,
-            'inputEventCounter' + i,
+            'inputEvent' + (i + numberOfFirstInput),
+            'inputEventCounter' + (i + numberOfFirstInput),
+            i + 1
+          ))
+        }
+
+        this.abilities.push(new ServiceLabelAbility())
+      }
+    }
+  }
+
+  class ShellyInputStatelessToggleAccessory extends ShellyAccessory {
+    constructor(device, index, config, log, numberOfInputs = 1, numberOfFirstInput = 0) {
+      super('statelessToggle', device, index, config, log)
+
+      if (numberOfInputs === 1) {
+        this.abilities.push(new StatelessProgrammableToggleAbility(
+          'input' + numberOfFirstInput,
+          'inputEventCounter' + numberOfFirstInput
+        ))
+      } else {
+        for (let i = 0; i < numberOfInputs; i++) {
+          this.abilities.push(new StatelessProgrammableToggleAbility(
+            'input' + (i + numberOfFirstInput),
+            'inputEventCounter' + (i + numberOfFirstInput),
             i + 1
           ))
         }
@@ -44,5 +69,6 @@ module.exports = homebridge => {
   return {
     ShellyButton1StatelessSwitchAccessory,
     ShellyInputStatelessSwitchAccessory,
+    ShellyInputStatelessToggleAccessory,
   }
 }

--- a/config.schema.json
+++ b/config.schema.json
@@ -88,6 +88,7 @@
                   "outlet",
                   "sensor",
                   "statelessSwitch",
+                  "statelessToggle",
                   "switch",
                   "valve",
                   "whiteLightbulb",


### PR DESCRIPTION
Added two new types for Shelly 1L: statelessSwitch (short/double/long) and statelessToggle (short on each activation (0->1 or 1->0).

Fixes #398.